### PR TITLE
Add an API key for spoonacular

### DIFF
--- a/config
+++ b/config
@@ -1,0 +1,1 @@
+spoonacular_apikey: 5e0356f3b7bd454886811a57765cecf9 # A free user with a free plan


### PR DESCRIPTION
This should usually not be public, however this key is
a free user
on a free plan

Therefore it can easily be recreated